### PR TITLE
prometheus_connect: Store "variance" operation result with the correc…

### DIFF
--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -485,7 +485,7 @@ class PrometheusConnect:
             elif operation == "deviation":
                 aggregated_values["deviation"] = numpy.std(np_array)
             elif operation == "variance":
-                aggregated_values["deviation"] = numpy.var(np_array)
+                aggregated_values["variance"] = numpy.var(np_array)
             else:
                 raise TypeError("Invalid operation: " + operation)
         return aggregated_values


### PR DESCRIPTION
…t key

This PR is aims to FIX an issues with stored "variance" operation result:
It seems that the result is stored in the returned dict with the key "deviation" instead of "variance".
This PR fixes it. 

Signed-off-by: shimon-armis <shimon.turjeman@armis.com>