### PR TITLE
Call plot more than once

### DIFF
--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -187,10 +187,10 @@ class Metric:
             error_string = "Different metric labels"
         raise TypeError("Cannot Add different metric types. " + error_string)
 
-    def plot(self):
+    def plot(self, *args,  **kwargs):
         """Plot a very simple line graph for the metric time-series."""
         if _MPL_FOUND:
-            fig, axis = plt.subplots()
+            fig, axis = plt.subplots(*args, **kwargs)
             axis.plot_date(self.metric_values.ds, self.metric_values.y, linestyle=":")
             fig.autofmt_xdate()
         # if matplotlib was not imported

--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -91,6 +91,11 @@ class Metric:
         self.start_time = self.metric_values.iloc[0, 0]
         self.end_time = self.metric_values.iloc[-1, 0]
 
+        if _MPL_FOUND:
+            # We store the matplotpy plot information as Class variables
+            Metric._fig = None
+            Metric._axis = None
+
     def __eq__(self, other):
         """
         Overloading operator ``=``.
@@ -190,9 +195,21 @@ class Metric:
     def plot(self, *args,  **kwargs):
         """Plot a very simple line graph for the metric time-series."""
         if _MPL_FOUND:
-            fig, axis = plt.subplots(*args, **kwargs)
-            axis.plot_date(self.metric_values.ds, self.metric_values.y, linestyle=":")
-            fig.autofmt_xdate()
+            if not Metric._fig:
+                # One graph with potentially  N lines - if plot() is called twice
+                Metric._fig, Metric._axis = plt.subplots(*args, **kwargs)
+            Metric._axis.plot_date(self.metric_values.ds, self.metric_values.y,
+                linestyle="solid",
+                label=str(self.metric_name)
+            )
+            Metric._fig.autofmt_xdate()
+            # These are provided for documentation reasons only - it's presumptuous for this code to call them
+            # Metric._axis.set_xlabel('Date/Time')
+            # Metric._axis.set_ylabel('Metric')
+            # Metric._axis.set_title('Prometheus')
+            if len(Metric._axis.lines) > 1:
+                # We show a legend (or update the legend) if there's more than line on the plot
+                Metric._axis.legend()
         # if matplotlib was not imported
         else:
             raise ImportError("matplotlib was not found")


### PR DESCRIPTION
While looking at #252 I realized that some extra code would produce a nicer result. Now when calling plot() more than once, you get overlaid graphs(). This assumes that the passed metrics are from the same query. This works nicely; however, I wonder if adding `plot()` method to `class MetricsList` would actually be a better idea. 