### PR TITLE
feat: add get_label_names helper

### DIFF
--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -105,6 +105,34 @@ class PrometheusConnect:
         self._all_metrics = self.get_label_values(label_name="__name__", params=params)
         return self._all_metrics
 
+    def get_label_names(self, params: dict = None):
+        """
+        Get a list of all labels.
+
+        :param params: (dict) Optional dictionary containing GET parameters to be
+            sent along with the API request, such as "start", "end" or "match[]".
+        :returns: (list) A list of labels from the specified prometheus host
+        :raises:
+            (RequestException) Raises an exception in case of a connection error
+            (PrometheusApiClientException) Raises in case of non 200 response status code
+        """
+        params = params or {}
+        response = self._session.get(
+            "{0}/api/v1/labels".format(self.url),
+            verify=self.ssl_verification,
+            headers=self.headers,
+            params=params,
+            auth=self.auth,
+        )
+
+        if response.status_code == 200:
+            labels = response.json()["data"]
+        else:
+            raise PrometheusApiClientException(
+                "HTTP Status Code {} ({!r})".format(response.status_code, response.content)
+            )
+        return labels
+
     def get_label_values(self, label_name: str, params: dict = None):
         """
         Get a list of all values for the label.

--- a/tests/test_prometheus_connect.py
+++ b/tests/test_prometheus_connect.py
@@ -135,6 +135,11 @@ class TestPrometheusConnect(unittest.TestCase):
         with self.assertRaises(requests.exceptions.RetryError, msg="too many 400 error responses"):
             pc.custom_query("BOOM.BOOM!#$%")
 
+    def test_get_label_names_method(self):  # noqa D102
+        labels = self.pc.get_label_names(params={"match[]": "up"})
+        self.assertEqual(len(labels), 4)
+        self.assertEqual(labels, ["__name__", "env", "instance", "job"])
+
 
 class TestPrometheusConnectWithMockedNetwork(BaseMockedNetworkTestcase):
     """Network is blocked in this testcase, see base class."""
@@ -210,6 +215,15 @@ class TestPrometheusConnectWithMockedNetwork(BaseMockedNetworkTestcase):
             self.assertEqual(handler.call_count, 1)
             request = handler.requests[0]
             self.assertEqual(request.path_url, "/api/v1/label/__name__/values")
+
+    def test_get_label_names_method(self):  # noqa D102
+        all_metrics_payload = {"status": "success", "data": ["value1", "value2"]}
+
+        with self.mock_response(all_metrics_payload) as handler:
+            self.assertTrue(len(self.pc.get_label_names()))
+            self.assertEqual(handler.call_count, 1)
+            request = handler.requests[0]
+            self.assertEqual(request.path_url, "/api/v1/labels")
 
     def test_get_label_values_method(self):  # noqa D102
         all_metrics_payload = {"status": "success", "data": ["value1", "value2"]}


### PR DESCRIPTION
```python

from prometheus_api_client import PrometheusConnect
prom = PrometheusConnect(url ="https://prometheus.demo.do.prometheus.io")

# Get the list of all the metrics that the Prometheus host scrapes
metrics = prom.all_metrics()
for metric in metrics:
    print(metric, "\n     labels:", prom.get_label_names(params={'match[]': metric}))

```

output:
```txt
[...]
node_memory_Shmem_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_Slab_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_SwapCached_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_SwapFree_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_SwapTotal_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_Unevictable_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_VmallocChunk_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
node_memory_VmallocTotal_bytes 
     labels: ['__name__', 'env', 'instance', 'job']
[...]
```