### PR TITLE
add pool_size setting

### DIFF
--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -34,6 +34,7 @@ class PrometheusConnect:
     :param disable_ssl: (bool) If set to True, will disable ssl certificate verification
         for the http requests made to the prometheus host
     :param retry: (Retry) Retry adapter to retry on HTTP errors
+    :param pool_size: (int) Number of connections that can be used. Default is 10
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth. See python
         requests library auth parameter for further explanation.
     :param proxy: (Optional) Proxies dictonary to enable connection through proxy. 
@@ -46,6 +47,7 @@ class PrometheusConnect:
         headers: dict = None,
         disable_ssl: bool = False,
         retry: Retry = None,
+        pool_size: int = 10,
         auth: tuple = None,
         proxy: dict = None
     ):
@@ -66,12 +68,13 @@ class PrometheusConnect:
                 status_forcelist=RETRY_ON_STATUS,
             )
 
+        self.pool_size = pool_size
         self.auth = auth
 
         self._session = requests.Session()
         if proxy is not None:
             self._session.proxies = proxy
-        self._session.mount(self.url, HTTPAdapter(max_retries=retry))
+        self._session.mount(self.url, HTTPAdapter(max_retries=retry, pool_maxsize=self.pool_size))
 
     def check_prometheus_connection(self, params: dict = None) -> bool:
         """

--- a/tests/test_prometheus_connect.py
+++ b/tests/test_prometheus_connect.py
@@ -17,7 +17,7 @@ class TestPrometheusConnect(unittest.TestCase):
     def setUp(self):
         """Set up connection settings for prometheus."""
         self.prometheus_host = os.getenv("PROM_URL")
-        self.pc = PrometheusConnect(url=self.prometheus_host, disable_ssl=True)
+        self.pc = PrometheusConnect(url=self.prometheus_host, disable_ssl=True, pool_size=2)
 
     def test_metrics_list(self):
         """Check if setup was done correctly."""
@@ -145,7 +145,7 @@ class TestPrometheusConnectWithMockedNetwork(BaseMockedNetworkTestcase):
     """Network is blocked in this testcase, see base class."""
 
     def setUp(self):  # noqa D102
-        self.pc = PrometheusConnect(url="http://doesnt_matter.xyz", disable_ssl=True)
+        self.pc = PrometheusConnect(url="http://doesnt_matter.xyz", disable_ssl=True, pool_size=2)
 
     def test_network_is_blocked(self):  # noqa D102
         resp = requests.get("https://google.com")


### PR DESCRIPTION
In the case of multithreaded use, it could be useful to be able to adjust the max_poolsize


Added pool_size option in PrometeusConnect which sets a max_poolsize on the HTTPAdapter request session
