### PR TITLE
feature/jmcc allow custom session to be provided

### DIFF
--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -60,7 +60,6 @@ class PrometheusConnect:
         self.url = url
         self.prometheus_host = urlparse(self.url).netloc
         self._all_metrics = None
-        self.ssl_verification = not disable_ssl
 
         if retry is None:
             retry = Retry(
@@ -71,7 +70,11 @@ class PrometheusConnect:
 
         self.auth = auth
 
-        self._session = session if session is not None else requests.Session()
+        if session is not None:
+            self._session == session
+        else:
+            self._session = requests.Session()
+            self._session.verify = not disable_ssl
 
         if proxy is not None:
             self._session.proxies = proxy
@@ -87,7 +90,7 @@ class PrometheusConnect:
         """
         response = self._session.get(
             "{0}/".format(self.url),
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             params=params,
             auth=self.auth,
@@ -124,7 +127,7 @@ class PrometheusConnect:
         params = params or {}
         response = self._session.get(
             "{0}/api/v1/labels".format(self.url),
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             params=params,
             auth=self.auth,
@@ -154,7 +157,7 @@ class PrometheusConnect:
         params = params or {}
         response = self._session.get(
             "{0}/api/v1/label/{1}/values".format(self.url, label_name),
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             params=params,
             auth=self.auth,
@@ -206,7 +209,7 @@ class PrometheusConnect:
         response = self._session.get(
             "{0}/api/v1/query".format(self.url),
             params={**{"query": query}, **params},
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
             cert=self._session.cert
@@ -298,7 +301,7 @@ class PrometheusConnect:
                     },
                     **params,
                 },
-                verify=self.ssl_verification,
+                verify=self._session.verify,
                 headers=self.headers,
                 auth=self.auth,
                 cert=self._session.cert
@@ -397,7 +400,7 @@ class PrometheusConnect:
         response = self._session.get(
             "{0}/api/v1/query".format(self.url),
             params={**{"query": query}, **params},
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
             cert=self._session.cert
@@ -441,7 +444,7 @@ class PrometheusConnect:
         response = self._session.get(
             "{0}/api/v1/query_range".format(self.url),
             params={**{"query": query, "start": start, "end": end, "step": step}, **params},
-            verify=self.ssl_verification,
+            verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
             cert=self._session.cert

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from requests import Session
 
 from .exceptions import PrometheusApiClientException
 
@@ -36,8 +37,9 @@ class PrometheusConnect:
     :param retry: (Retry) Retry adapter to retry on HTTP errors
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth. See python
         requests library auth parameter for further explanation.
-    :param proxy: (Optional) Proxies dictonary to enable connection through proxy. 
-        Example: {"http_proxy": "<ip_address/hostname:port>", "https_proxy": "<ip_address/hostname:port>"}  
+    :param proxy: (Optional) Proxies dictionary to enable connection through proxy.
+        Example: {"http_proxy": "<ip_address/hostname:port>", "https_proxy": "<ip_address/hostname:port>"}
+    :param session (Optional) Custom requests.Session to enable complex HTTP configuration
     """
 
     def __init__(
@@ -47,7 +49,8 @@ class PrometheusConnect:
         disable_ssl: bool = False,
         retry: Retry = None,
         auth: tuple = None,
-        proxy: dict = None
+        proxy: dict = None,
+        session: Session = None,
     ):
         """Functions as a Constructor for the class PrometheusConnect."""
         if url is None:
@@ -68,7 +71,8 @@ class PrometheusConnect:
 
         self.auth = auth
 
-        self._session = requests.Session()
+        self._session = session if session is not None else requests.Session()
+
         if proxy is not None:
             self._session.proxies = proxy
         self._session.mount(self.url, HTTPAdapter(max_retries=retry))

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -71,7 +71,7 @@ class PrometheusConnect:
         self.auth = auth
 
         if session is not None:
-            self._session == session
+            self._session = session
         else:
             self._session = requests.Session()
             self._session.verify = not disable_ssl

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -91,6 +91,7 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
+            cert=self._session.cert
         )
         return response.ok
 
@@ -127,6 +128,7 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
+            cert=self._session.cert
         )
 
         if response.status_code == 200:
@@ -156,6 +158,7 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
+            cert=self._session.cert
         )
 
         if response.status_code == 200:
@@ -206,6 +209,7 @@ class PrometheusConnect:
             verify=self.ssl_verification,
             headers=self.headers,
             auth=self.auth,
+            cert=self._session.cert
         )
 
         if response.status_code == 200:
@@ -297,6 +301,7 @@ class PrometheusConnect:
                 verify=self.ssl_verification,
                 headers=self.headers,
                 auth=self.auth,
+                cert=self._session.cert
             )
             if response.status_code == 200:
                 data += response.json()["data"]["result"]
@@ -395,6 +400,7 @@ class PrometheusConnect:
             verify=self.ssl_verification,
             headers=self.headers,
             auth=self.auth,
+            cert=self._session.cert
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]
@@ -438,6 +444,7 @@ class PrometheusConnect:
             verify=self.ssl_verification,
             headers=self.headers,
             auth=self.auth,
+            cert=self._session.cert
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]


### PR DESCRIPTION
We ran into this issue when attempting to use mTLS to connect to a prometheus instance, but there are several examples where it may be useful to allow for complex `Session` configurations.

If there are any changes you'd like me to make, please let me know!

Thanks,
Josh
