### PR TITLE
#277 Add the ability to specify request timeouts

### DIFF
--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -396,6 +396,7 @@ class PrometheusConnect:
             at https://prometheus.io/docs/prometheus/latest/querying/examples/
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "time"
+        :param timeout: (int) A timeout (in seconds) applied to the request
         :returns: (list) A list of metric data received in response of the query sent
         :raises:
             (RequestException) Raises an exception in case of a connection error
@@ -404,6 +405,7 @@ class PrometheusConnect:
         params = params or {}
         data = None
         query = str(query)
+        timeout = self._timeout if timeout is None else timeout
         # using the query API to get raw data
         response = self._session.get(
             "{0}/api/v1/query".format(self.url),
@@ -412,7 +414,7 @@ class PrometheusConnect:
             headers=self.headers,
             auth=self.auth,
             cert=self._session.cert,
-            timeout=self._timeout,
+            timeout=timeout,
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]
@@ -424,7 +426,7 @@ class PrometheusConnect:
         return data
 
     def custom_query_range(
-        self, query: str, start_time: datetime, end_time: datetime, step: str, params: dict = None
+        self, query: str, start_time: datetime, end_time: datetime, step: str, params: dict = None, timeout: int = None
     ):
         """
         Send a query_range to a Prometheus Host.
@@ -439,6 +441,7 @@ class PrometheusConnect:
         :param step: (str) Query resolution step width in duration format or float number of seconds
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "timeout"
+        :param timeout: (int) A timeout (in seconds) applied to the request
         :returns: (dict) A dict of metric data received in response of the query sent
         :raises:
             (RequestException) Raises an exception in case of a connection error
@@ -449,6 +452,7 @@ class PrometheusConnect:
         params = params or {}
         data = None
         query = str(query)
+        timeout = self._timeout if timeout is None else timeout
         # using the query_range API to get raw data
         response = self._session.get(
             "{0}/api/v1/query_range".format(self.url),
@@ -457,7 +461,7 @@ class PrometheusConnect:
             headers=self.headers,
             auth=self.auth,
             cert=self._session.cert,
-            timeout=self._timeout,
+            timeout=timeout,
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -40,6 +40,7 @@ class PrometheusConnect:
     :param proxy: (Optional) Proxies dictionary to enable connection through proxy.
         Example: {"http_proxy": "<ip_address/hostname:port>", "https_proxy": "<ip_address/hostname:port>"}
     :param session (Optional) Custom requests.Session to enable complex HTTP configuration
+    :param timeout: (int) A timeout (in seconds) applied to all requests
     """
 
     def __init__(
@@ -51,6 +52,7 @@ class PrometheusConnect:
         auth: tuple = None,
         proxy: dict = None,
         session: Session = None,
+        timeout: int = None,
     ):
         """Functions as a Constructor for the class PrometheusConnect."""
         if url is None:
@@ -60,6 +62,7 @@ class PrometheusConnect:
         self.url = url
         self.prometheus_host = urlparse(self.url).netloc
         self._all_metrics = None
+        self._timeout = timeout
 
         if retry is None:
             retry = Retry(
@@ -94,7 +97,8 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
         return response.ok
 
@@ -131,7 +135,8 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
 
         if response.status_code == 200:
@@ -161,7 +166,8 @@ class PrometheusConnect:
             headers=self.headers,
             params=params,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
 
         if response.status_code == 200:
@@ -212,7 +218,8 @@ class PrometheusConnect:
             verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
 
         if response.status_code == 200:
@@ -304,7 +311,8 @@ class PrometheusConnect:
                 verify=self._session.verify,
                 headers=self.headers,
                 auth=self.auth,
-                cert=self._session.cert
+                cert=self._session.cert,
+                timeout=self._timeout,
             )
             if response.status_code == 200:
                 data += response.json()["data"]["result"]
@@ -377,7 +385,7 @@ class PrometheusConnect:
         )
         return object_path
 
-    def custom_query(self, query: str, params: dict = None):
+    def custom_query(self, query: str, params: dict = None, timeout: int = None):
         """
         Send a custom query to a Prometheus Host.
 
@@ -403,7 +411,8 @@ class PrometheusConnect:
             verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]
@@ -447,7 +456,8 @@ class PrometheusConnect:
             verify=self._session.verify,
             headers=self.headers,
             auth=self.auth,
-            cert=self._session.cert
+            cert=self._session.cert,
+            timeout=self._timeout,
         )
         if response.status_code == 200:
             data = response.json()["data"]["result"]

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -40,7 +40,7 @@ class PrometheusConnect:
     :param proxy: (Optional) Proxies dictionary to enable connection through proxy.
         Example: {"http_proxy": "<ip_address/hostname:port>", "https_proxy": "<ip_address/hostname:port>"}
     :param session (Optional) Custom requests.Session to enable complex HTTP configuration
-    :param timeout: (int) A timeout (in seconds) applied to all requests
+    :param timeout: (Optional) A timeout (in seconds) applied to all requests
     """
 
     def __init__(
@@ -396,7 +396,7 @@ class PrometheusConnect:
             at https://prometheus.io/docs/prometheus/latest/querying/examples/
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "time"
-        :param timeout: (int) A timeout (in seconds) applied to the request
+        :param timeout: (Optional) A timeout (in seconds) applied to the request
         :returns: (list) A list of metric data received in response of the query sent
         :raises:
             (RequestException) Raises an exception in case of a connection error
@@ -441,7 +441,7 @@ class PrometheusConnect:
         :param step: (str) Query resolution step width in duration format or float number of seconds
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "timeout"
-        :param timeout: (int) A timeout (in seconds) applied to the request
+        :param timeout: (Optional) A timeout (in seconds) applied to the request
         :returns: (dict) A dict of metric data received in response of the query sent
         :raises:
             (RequestException) Raises an exception in case of a connection error


### PR DESCRIPTION
# Summary

I am adding the ability to configure request timeouts.

# Details

- Add a global request timeout object to be used for all requests (https://github.com/4n4nd/prometheus-api-client-python/commit/a0dcfcf8448ed5a0815f1fd15e5fd6d975bf0f71)
- Add request timeouts for custom queries, which overwrite the global timeout if set (https://github.com/4n4nd/prometheus-api-client-python/commit/e0dd4a623bb9659cc27a7be51abc9b05668696b1)

# References

- Fixes https://github.com/4n4nd/prometheus-api-client-python/issues/277