### PR TITLE
make matplotlib optional

### DIFF
--- a/prometheus_api_client/__init__.py
+++ b/prometheus_api_client/__init__.py
@@ -1,6 +1,6 @@
 """A collection of tools to collect and manipulate prometheus metrics."""
 
-__title__ = "prometheus-connect"
+__title__ = "prometheus-api-client-optional-matplotlib"
 __version__ = "0.6.0"
 
 from .prometheus_connect import *  # noqa F403

--- a/prometheus_api_client/metric_plot.py
+++ b/prometheus_api_client/metric_plot.py
@@ -22,7 +22,10 @@ class MetricPlot:
 
             register_matplotlib_converters()
         except ImportError as exce:  # noqa F841
-            raise ImportError("matplotlib was not found")
+            raise ImportError(
+                "matplotlib is required for plotting functionality. "
+                "Install with: pip install 'prometheus-api-client[plotting]'"
+            )
 
         # One graph with potentially N lines - if plot() is called twice
         self._plt = plt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ requests
 dateparser
 pandas>=1.4.0
 numpy
-matplotlib
 httmock

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ def get_version():
 
 VERSION = get_version()
 setuptools.setup(
-    name="prometheus-api-client",
+    name="prometheus-api-client-optional-matplotlib",
     version=VERSION,
     author="Anand Sanmukhani",
     author_email="asanmukhani@microsoft.com",
-    description="A small python api to collect data from prometheus",
+    description="A Python API client for Prometheus with optional matplotlib dependency",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/4n4nd/prometheus-api-client-python",


### PR DESCRIPTION
Fixes #225
This is a breaking change for users, but it solves a major painpoint for end users who don't want to pull in unecessary dependencies.

I've pushed a version of the package to pypi at https://pypi.org/project/prometheus-api-client-optional-matplotlib/ which is a drop-in replacement for prometheus-api-client without the matplotlib dependency.