### PR TITLE
Remove tests from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include requirements.txt
-prune test
+prune tests


### PR DESCRIPTION
If installing this with another package that is shipping their tests, this creates a conflict and we can't install both libraries. This prevents it from working. Removing tests from the packaging to avoid the conflicts.