### PR TITLE
Allow creation of Metric from datastructure without __name__

### DIFF
--- a/prometheus_api_client/metric.py
+++ b/prometheus_api_client/metric.py
@@ -54,10 +54,9 @@ class Metric:
             self.metric_values = metric.metric_values
             self.oldest_data_datetime = oldest_data_datetime
         else:
-            self.metric_name = metric["metric"]["__name__"]
+            self.metric_name = metric["metric"].pop("__name__", None)
             self.label_config = deepcopy(metric["metric"])
             self.oldest_data_datetime = oldest_data_datetime
-            del self.label_config["__name__"]
 
             # if it is a single value metric change key name
             if "value" in metric:


### PR DESCRIPTION
When applying a function to a time series in a query to Prometheus, the Prometheus server returns a data structure without `__name__` key. Apart from that aspect, the time series could still be used to create a Metric object.

This PR proposes to set "metric_name" to None when `__name__` is missing.