### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,7 +200,7 @@ epub_exclude_files = ["search.html"]
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/prometheus_api_client/metric_range_df.py
+++ b/prometheus_api_client/metric_range_df.py
@@ -42,7 +42,7 @@ class MetricRangeDataFrame(DataFrame):
       .. code-block:: python
 
           prom = PrometheusConnect()
-          metric_data = prom.get_current_metric_value(metric_name='up', label_config=my_label_config)
+          metric_data = prom.get_metric_range_data(metric_name='up', label_config=my_label_config)
           metric_df = MetricRangeDataFrame(metric_data)
           metric_df.head()
           '''

--- a/prometheus_api_client/prometheus_connect.py
+++ b/prometheus_api_client/prometheus_connect.py
@@ -38,7 +38,7 @@ class PrometheusConnect:
         requests library auth parameter for further explanation.
     :param proxy: (Optional) Proxies dictionary to enable connection through proxy.
         Example: {"http_proxy": "<ip_address/hostname:port>", "https_proxy": "<ip_address/hostname:port>"}
-    :param session (Optional) Custom requests.Session to enable complex HTTP configuration
+    :param session: (Optional) Custom requests.Session to enable complex HTTP configuration
     :param timeout: (Optional) A timeout (in seconds) applied to all requests
     :param method: (Optional) (str) HTTP Method (GET or POST) to use for Query APIs that allow POST 
         (/query, /query_range and /labels). Use POST for large and complex queries. Default is GET.
@@ -444,8 +444,8 @@ class PrometheusConnect:
         This method takes as input a string which will be sent as a query to
         the specified Prometheus Host. This query is a PromQL query.
 
-        :param query: (str) This is a PromQL query, a few examples can be found
-            at https://prometheus.io/docs/prometheus/latest/querying/examples/
+        :param query: (str) This is a PromQL query, a few examples can be found at
+            `PromQL query examples <https://prometheus.io/docs/prometheus/latest/querying/examples/>`_
         :param params: (dict) Optional dictionary containing GET parameters to be
             sent along with the API request, such as "time"
         :param timeout: (Optional) A timeout (in seconds) applied to the request
@@ -487,8 +487,8 @@ class PrometheusConnect:
         This method takes as input a string which will be sent as a query to
         the specified Prometheus Host. This query is a PromQL query.
 
-        :param query: (str) This is a PromQL query, a few examples can be found
-            at https://prometheus.io/docs/prometheus/latest/querying/examples/
+        :param query: (str) This is a PromQL query, a few examples can be found at
+            `PromQL query examples <https://prometheus.io/docs/prometheus/latest/querying/examples/>`_
         :param start_time: (datetime) A datetime object that specifies the query range start time.
         :param end_time: (datetime) A datetime object that specifies the query range end time.
         :param step: (str) Query resolution step width in duration format or float number of seconds
@@ -545,8 +545,8 @@ class PrometheusConnect:
         The received query is passed to the custom_query_range method which returns
         the result of the query and the values are extracted from the result.
 
-        :param query: (str) This is a PromQL query, a few examples can be found
-          at https://prometheus.io/docs/prometheus/latest/querying/examples/
+        :param query: (str) This is a PromQL query, a few examples can be found at
+          `PromQL query examples <https://prometheus.io/docs/prometheus/latest/querying/examples/>`_
         :param operations: (list) A list of operations to perform on the values.
           Operations are specified in string type.
         :param start_time: (datetime) A datetime object that specifies the query range start time.


### PR DESCRIPTION
1. Updates intersphinx mapping to follow syntax used in example on official Sphinx docs [here](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html)
2. Updates metric-getter function used in docstring for MetricRangeDataFrame
3. Fixes hyperlink formatting so it docs render correctly.

Closes #275 