### PR TITLE
Fix ReadTheDocs configuration to restore docs updates

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# ReadTheDocs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - all

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,8 @@ Welcome to Prometheus Client API Python's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   source/modules
+
 
 
 Indices and tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-rtd-theme


### PR DESCRIPTION
Fixes the ReadTheDocs page not updating since v0.4.1 by adding required configuration file and fixing documentation structure.

**Changes:**
- Add `.readthedocs.yaml` (required by ReadTheDocs for modern builds)
- Fix `docs/index.rst` to include `source/modules` in toctree
- Add `docs/requirements.txt` with Sphinx dependencies

Fixes #324

Generated with [Claude Code](https://claude.ai/code)